### PR TITLE
Use `replaceWith`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ on('.anticore > main, .anticore title', (element, url) => {
   const current = document.querySelector(selector)
 
   // replacing the embedded element by the new one
-  current.parentNode.replaceChild(element, current)
+  current.replaceWith(element)
 
   if (selector === 'title') {
     // updating the history


### PR DESCRIPTION
Adding [`replaceWith`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/replaceWith). Feel free to ignore if you want to minimize the need for polyfills for people working against older browsers like IE. But the [ChildNode](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode) and [ParentNode](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode) APIs do make life rather nice.